### PR TITLE
Swap back to bashtestdummy directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'json'
 require 'find'
 
 def coverage_data
-  coverage_file_name = '/usr/src/app/coverage/kcov-merged/coverage.json'
+  coverage_file_name = '/usr/src/app/coverage/bashtestdummy/coverage.json'
   coverage_json = File.read(coverage_file_name)
   JSON.parse(coverage_json)
 end


### PR DESCRIPTION
Looks like when I swapped the script name, kcov got confused after seeing coverage in both 'integration-test.sh' and 'bashtestdummy' and merged it into a third directory.  Once you clear out 'coverage', it starts putting things back in 'bashtestdummy', where it belongs.