### PR TITLE
Switch to python 3 to satisfy kcov build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update
 # is installed we do not repeat the whole image build.
 RUN apt-get install -y --fix-missing pkg-config
 RUN apt-get install -y zlib1g wget libcurl4-openssl-dev libelf-dev libdw-dev cmake cmake-data g++ binutils-dev \
-                       libiberty-dev zlib1g-dev python-minimal git
+                       libiberty-dev zlib1g-dev python3-minimal git
 
 ENV SRC_DIR=/home/kcov-src \
     URL_GIT_KCOV=https://github.com/SimonKagstrom/kcov.git


### PR DESCRIPTION
The newest kcov seems to require Python 3 for its build:

https://hub.docker.com/repository/registry-1.docker.io/bluelabsio/bashtestdummy/builds/7d4a746a-d814-4d1f-b6c9-88e966d844c0