### PR TITLE
Run tests as a non-prived user and avoid kcov limitation (BREAKING) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,8 @@ WORKDIR /usr/src/app
 
 VOLUME /usr/src/app
 
+RUN groupadd -r bashtestdummy && useradd --create-home --system --gid bashtestdummy bashtestdummy
+
+USER bashtestdummy
+
 ENTRYPOINT ["/usr/bin/rake", "-f", "/usr/bashtestdummy/Rakefile", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 #
 # Pull in kcov for shell script test coverage.
 #
 # Scripts taken from https://github.com/Ragnaroek/kcov_docker/blob/master/Dockerfile
 #
-
-ARG KCOV_GIT_REF
 
 RUN apt-get update
 # install pkg-config deliberately separate since it sometimes fails :( If it eventually
@@ -17,6 +15,8 @@ RUN apt-get install -y zlib1g wget libcurl4-openssl-dev libelf-dev libdw-dev cma
 
 ENV SRC_DIR=/home/kcov-src \
     URL_GIT_KCOV=https://github.com/SimonKagstrom/kcov.git
+
+ARG KCOV_GIT_REF=v37
 
 RUN git clone $URL_GIT_KCOV $SRC_DIR; \
     cd $SRC_DIR; \

--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ Some related work on the internet:
   Seems to be related to support some kind of XML output.
 * [shunit2](https://github.com/kward/shunit2)
   Seems a little on the unmaintained side.
+* [shellspec](https://github.com/shellspec/shellspec) - BDD-style
+  testing framework

--- a/example/tests/Dockerfile
+++ b/example/tests/Dockerfile
@@ -1,8 +1,13 @@
 FROM bluelabsio/bashtestdummy:latest
 
+USER root
+
 #
 # Build cowsay
 #
 
 RUN apt-get update -y && apt-get install -y cowsay
+
+USER bashtestdummy
+
 ENV PATH /usr/games:$PATH

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+version="${1:?version}"
+
+if [[ ${version:?} == v* ]]
+then
+  >&2 echo "Please provide only numbers separated by dots"
+  exit 1
+fi
+
+git tag -m "Tag v${version:?}" -a "v${version}" "$(git rev-parse HEAD)"
+git push --follow-tags


### PR DESCRIPTION
kcov depends on the PS4 variable, which due to a bash security fix, no longer works when bash is run as root:

https://github.com/SimonKagstrom/kcov/issues/234

This results in no coverage analysis when run on a recent Docker base image that contains the bash security fix.

Running as a non-prived user in Docker works around the limitation.

This is a breaking changes on projects downstream, which need to adapt their Dockerfiles to run tests as the non-prived "bashtestdummy" user, yet install dependencies as root.  `example/tests/Dockerfile` has been updated to match.

I've also added a few other changes:
* Add a publish.sh script so we can start managing versions on the project in case of future breaking changes.
* A quick README update for another shell testing framework I found out about while crawling through kcov issues.
* In the spirit of not breaking things until we plan to break things, and making debugging a little more straightforward when things do break unexpectedly, fix the OS and kcov versions to a specific value.
